### PR TITLE
Add comprehensive documentation for iNews workflow

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,42 @@
+# Hướng dẫn đóng góp cho INEWS Tools
+
+## Yêu cầu môi trường
+- Visual Studio 2019 hoặc 2022 với workload **.NET Desktop Development**.
+- .NET Framework 4.8 SDK (được cài cùng Visual Studio).
+- Khả năng truy cập tới máy chủ iNews Web Service (địa chỉ trong `app.config`).
+
+## Chuẩn bị cấu hình
+1. Sao chép `API_iNews/app.config` và cập nhật các khóa sau theo môi trường nội bộ:
+   - `ServerIP`: địa chỉ TCP server nội bộ.
+   - `iNewsServer`, `iNewsServerBackup`: endpoint SOAP.
+   - `iNewsUser`, `iNewsPass`: tài khoản thử nghiệm.
+   - `WorkingFolder`: thư mục ghi file tạm.
+2. Không commit thông tin nhạy cảm lên repository công khai.
+
+## Quy trình làm việc
+1. Fork repository và tạo nhánh theo tính năng (ví dụ `feature/export-json`).
+2. Thực hiện chỉnh sửa, bảo đảm giữ nguyên mô hình phân lớp (`API` UI ↔ `ServerAPI` ↔ `iNewsData`).
+3. Kiểm tra thủ công (xem mục “Kiểm thử” bên dưới).
+4. Cập nhật tài liệu (README/ProjectOverview/ModuleGuide) nếu thay đổi workflow kết nối hoặc cấu hình.
+5. Tạo Pull Request mô tả rõ:
+   - Mục đích thay đổi.
+   - Ảnh hưởng tới workflow kết nối iNews (nếu có).
+   - Bằng chứng kiểm thử (log, ảnh chụp màn hình UI).
+
+## Tiêu chuẩn code
+- **Naming**: giữ nguyên pattern event handler của WinForms (`btnXuatTroiTin_Click`, `treeView1_AfterSelect`).
+- **Cấu hình**: đọc qua `ConfigurationManager.AppSettings`; không hard-code IP/tài khoản.
+- **Bất đồng bộ**: sử dụng `Task.Run`/`async` cho thao tác SOAP hoặc IO dài; tránh chặn UI thread.
+- **Xử lý lỗi**: log mọi exception thông qua `iNewsData.SentError` hoặc hiển thị `MessageBox`, đảm bảo người dùng biết trạng thái kết nối.
+- **Web References**: nếu cập nhật wsdl, commit cả thư mục `Web References` để đồng bộ proxy.
+
+## Kiểm thử đề xuất
+- ✅ **Khởi động & kết nối**: chạy ứng dụng, kiểm tra status bar hiển thị IP và không có lỗi kết nối.
+- ✅ **Lazy-load queue**: mở rộng vài node trong `treeView1`, đảm bảo dữ liệu tải đúng.
+- ✅ **Tải story**: chọn rundown bất kỳ, xác minh `dataGridView1` hiển thị story và `txtContent` có dữ liệu.
+- ✅ **Xuất file**: chạy từng nút export và kiểm tra file được tạo trong `WorkingFolder`.
+- ✅ **Server TCP**: dùng `ClientForm` gửi `GET_TREE` và `QUEUE|<FullName>` để đảm bảo phản hồi hợp lệ.
+
+## Liên hệ & hỗ trợ
+- Đề xuất mọi câu hỏi kỹ thuật qua phần Issues của repository.
+- Khi gặp lỗi kết nối iNews, cung cấp log `toolStripStatusLabel1` và giá trị cấu hình liên quan.

--- a/ModuleGuide.md
+++ b/ModuleGuide.md
@@ -1,0 +1,54 @@
+# Danh mục lớp & module chính
+
+## Bản đồ chức năng
+| Tệp/Lớp | Vai trò | Ghi chú workflow |
+| --- | --- | --- |
+| `Program.cs` | Khởi động ứng dụng WinForms (`Application.Run(new API())`). | Không chỉnh sửa trừ khi thay đổi form khởi động. |
+| `API.cs` | Form chính: quản lý kết nối iNews, hiển thị rundown/story, xuất file. | `ConnectServerToLoadDataAsync` đọc app.config, tạo `ServerAPI` và `iNewsData`; `treeView1_*` điều phối việc load queue/story; các nút `Export*` dùng dữ liệu `Content`. |
+| `ServerAPI.cs` | TCP server nội bộ. | `ListenForClients` đọc lệnh `GET_TREE`, `QUEUE|...`, sử dụng `iNewsData` để trả dữ liệu; event `Recieve` cập nhật status bar. |
+| `ClientAPI.cs` | TCP client tiện ích cho `ClientForm`. | `GetDataFromCmd` gửi lệnh và trả về chuỗi phản hồi. |
+| `iNews.cs` | Wrapper kết nối SOAP (class `iNews`) và tầng tiện ích (`iNewsData`). | `iNews` thiết lập `INEWSSystem`, `INEWSQueue`, đăng nhập bằng `Servername/User/Pass`; `iNewsData` cung cấp `GetFolderChildren`, `GetStoriesBoard`, `ChangedQueues`. |
+| `ProcessingXMl2Class` | Chuyển NSML sang `DataTable`. | Sử dụng `FieldMapping` từ cấu hình `Fields`; lưu `Content` cho thao tác export. |
+| `Utility.cs` | Hàm phụ trợ (split chuỗi, hiển thị XML). | `Utility.Split` dùng để phân tách queue root. |
+| `ServerForm` | Form điều khiển server TCP. | Cho phép start/stop server, mở `API` hoặc `ClientForm`. |
+| `ClientForm` | Form kiểm thử lệnh TCP. | Buttons `btnGetTree`, `btnSendCommand`; nút `btnGetStories` đang rỗng – nên xử lý hoặc ẩn. |
+| `APIV4` | Form kế thừa dùng BarType. | Đọc `BarTypeConfiguration` để map scene/value. |
+| `BarTypeConfiguration.cs` | Định nghĩa cấu trúc `BarTypeCollection`. | Phục vụ tính năng BarScene trong `APIV4`. |
+| `WebServiceSettings.cs` | DTO chứa `ServerName`, `ServerBackup`, `UserName`, `Password`. | Được `API.ConnectServerToLoadDataAsync` khởi tạo từ app.config. |
+| `app.config` | Cấu hình kết nối, thư mục xuất file và khóa regex. | Chỉnh sửa trước khi chạy; cân nhắc bỏ khóa `Phude` nếu không dùng. |
+
+## Sự kiện UI quan trọng
+| Control | Event | Mục đích |
+| --- | --- | --- |
+| `API.treeView1` | `BeforeExpand` | Lazy-load queue con bằng `iNewsData.GetFolderChildren`. |
+|  | `AfterSelect` | Lấy stories cho rundown, cập nhật `dataGridView1`, `txtContent`, `txtTroiTin/Cuoi`. |
+| `API.dataGridView1` | `CellClick`, `SelectionChanged` (qua `GetDataContent`) | Cập nhật `Content` đang xem. |
+| `API.btnExportContentRaw` | `Click` | Lưu story hiện tại kèm tiêu đề. |
+| `API.Export3TXTFiles` | `Click` | Gọi `ProcessContentWithCG`/`ProcessContentWithDD` để xuất rút tít & địa danh. |
+| `API.btnXuatTroiTin` | `Click` | Gọi `LoadContentTroiTin`, `LoadContentTroiCuoi` rồi ghi ra file. |
+| `API.btnExportAllRawContent` | `Click` | Duyệt toàn bộ rundown, xuất tổng hợp nội dung. |
+| `ServerForm.btnStartServer` | `Click` | Mở `ServerAPI`. |
+| `ClientForm.btnGetTree` | `Click` | Gửi lệnh `GET_TREE` và bind kết quả vào treeview. |
+
+## Điểm vào workflow kết nối iNews
+1. `API_Load` → `ConnectServerToLoadDataAsync`.
+2. Hàm đọc `ServerIP`, `iNewsServer`, `iNewsServerBackup`, `iNewsUser`, `iNewsPass`, `QueuesRoot`, `QueuesChild`, `WorkingFolder`.
+3. Tạo `ServerAPI(serverIP)` và `iNewsData(new WebServiceSettings{...})`.
+4. Các phương thức trong bảng dưới sẽ gọi `iNewsData`:
+
+| Phương thức | Input chính | Kết quả |
+| --- | --- | --- |
+| `iNewsData.GetFolderChildren(string folderParent)` | `folderParent` (node full name). | Danh sách child folder (string). |
+| `iNewsData.GetStoriesBoard(string queueName)` | `queueName` (bao gồm hậu tố `QueuesChild` nếu cấu hình). | Danh sách story NSML. |
+| `iNewsData.ChangedQueues()` | Không | Danh sách queue thay đổi (dùng cho giám sát). |
+
+## Resource & config
+- `WorkingFolder` + đường dẫn con (`Ruttit`, `Diadanh`, `TroiTin`, `TroiCuoi`, `Phude`).
+- Các khóa regex `KeyTroiTin`, `KeyTroiCuoi` quyết định pattern tách nội dung.
+- `BarScene`, `BarLocaltion` phục vụ `BarTypeConfiguration`.
+- URL SOAP nằm trong `applicationSettings` (`API_iNews.Properties.Settings`).
+
+## Thành phần nên rà soát
+- `ProcessContentWithPhude` (không được gọi) – nên loại bỏ hoặc kích hoạt tính năng xuất phụ đề.
+- `ClientForm.btnGetStories` chưa có logic – dễ gây nhầm lẫn cho người dùng kiểm thử.
+- Case `GET_SCROLL_TEXT` trong `ServerAPI` trả chuỗi rỗng – cân nhắc cài đặt hoặc bỏ hẳn.

--- a/ProjectOverview.md
+++ b/ProjectOverview.md
@@ -1,0 +1,148 @@
+# Tổng quan kiến trúc INEWS Tools
+
+## Kiến trúc lớp & module
+Ứng dụng tách thành ba lớp chính:
+
+1. **UI WinForms** – các form `API`, `ServerForm`, `ClientForm`, `APIV4` để người dùng tương tác.
+2. **Dịch vụ nội bộ** – `ServerAPI` (TCP server) và `ClientAPI` (TCP client kiểm thử) trung gian trao đổi dữ liệu.
+3. **Truy xuất iNews** – `iNews`, `iNewsData`, `ProcessingXMl2Class` gọi SOAP Web Service và chuyển NSML thành `DataTable`.
+
+```mermaid
+graph TD
+    Program[[Program.cs]] --> APIForm[API Form]
+    APIForm -->|Khởi động dịch vụ| ServerAPI
+    APIForm -->|Đọc NSML| Processing[ProcessingXMl2Class]
+    ServerAPI --> iNewsData
+    iNewsData --> iNewsCore[iNews]
+    iNewsCore -->|SOAP| INEWS[Web References]
+    ServerAPI -->|TCP| ClientAPI
+    ClientAPI --> ClientForm
+    ServerForm --> ServerAPI
+    APIV4 --> Processing
+```
+
+## Luồng khởi động & kết nối iNews
+Quy trình kết nối rất quan trọng và diễn ra trong `API.ConnectServerToLoadDataAsync`:
+
+1. **Đọc cấu hình TCP**: lấy `ServerIP`, `WorkingFolder` từ `app.config`.
+2. **Khởi tạo ServerAPI**: truyền `ServerIP`, đăng ký sự kiện `Recieve`, gọi `Start()` để lắng nghe TCP.
+3. **Nạp thông số iNews**: đọc `iNewsServer`, `iNewsServerBackup`, `iNewsUser`, `iNewsPass`, `QueuesRoot`, `QueuesChild`.
+4. **Tạo `WebServiceSettings`**: gán các giá trị ở bước 3 rồi khởi tạo `iNewsData` với settings này.
+5. **Kết nối SOAP**: khi `iNewsData` cần dữ liệu, nó khởi tạo `TTDH.iNews`:
+   - Sinh `INEWSSystem` và `INEWSQueue` (proxy trong `Web References`).
+   - Tạo `CookieContainer` dùng chung cho cả hai dịch vụ.
+   - Thiết lập `Timeout = 5000ms`.
+   - Gọi `INEWSSystem.Connect` với `ConnectType` chứa `Servername`, `Username`, `Password` từ settings.
+   - Nếu kết nối thất bại và có `ServerBackup`, hàm tự thử lại.
+6. **Kiểm tra kết nối**: `iNews.IsConnected()` gọi `INEWSSystem.IsConnected` để xác nhận.
+7. **Dựng cây rundown**: `API.LoadTreeStoriesAsync` đọc `QueuesRoot`, sử dụng `iNewsData.GetFolderChildren` để lấy queue con cho từng node.
+
+Mọi lỗi khi kết nối hoặc gọi SOAP đều được truyền qua `iNewsData.SentError` để form hiển thị trong `toolStripStatusLabel1`.
+
+```mermaid
+flowchart TD
+    Start([Program]) --> Init[API_Load]
+    Init --> ReadCfg[Đọc appSettings]
+    ReadCfg --> StartTCP[Khởi động ServerAPI (ServerIP)]
+    StartTCP --> BuildSettings[Tạo WebServiceSettings]
+    BuildSettings --> CreateIData[Khởi tạo iNewsData]
+    CreateIData --> LoadTree[LoadTreeQueuesAsync]
+    LoadTree --> Ready[UI sẵn sàng]
+```
+
+## Lấy danh sách queue & story
+### Lấy queue con
+1. Khi mở rộng node, `treeView1_BeforeExpand` gọi `iNewsData.GetFolderChildren` với `FolderFullName` từ `TreeNode.Tag`.
+2. `GetFolderChildren` tạo `GetFolderChildrenType`, gọi `iNews.iNewsSystem.GetFolderChildren`, trả về `Children` danh sách folder.
+3. UI thêm node con và gán `Tag = parent.Tag + "." + child` để tiếp tục lazy-load.
+
+### Lấy story trong rundown
+1. `treeView1_AfterSelect` chuẩn bị tên queue (`selectedName`). Nếu có `QueuesChild`, ghép thêm hậu tố.
+2. Trong `Task.Run`, `iNewsData.GetStoriesBoard` thực thi:
+   - `SetCurrentQueueType.QueueFullName = queueName` rồi gọi `INEWSQueue.SetCurrentQueue`.
+   - Cấu hình `GetStoriesType` (`IsStoryBodyIncluded = true`, `NumberOfStoriesToGet = 240`, `Navigation = SAME`).
+   - Gọi `INEWSQueue.GetStories` để lấy danh sách NSML.
+3. Trả về `List<string>` story NSML cho `ProcessingXMl2Class`.
+4. `ProcessingXMl2Class.GetDataRows` map trường dựa trên cấu hình `Fields` và tạo `DataTable`.
+5. `dataGridView1` bind `DataTable`, textbox hiển thị nội dung story đã chọn.
+
+```mermaid
+sequenceDiagram
+    participant UI as API Form
+    participant IData as iNewsData
+    participant INews as TTDH.iNews
+    participant Sys as INEWSSystem
+    participant Queue as INEWSQueue
+
+    UI->>IData: GetStoriesBoard(queueName)
+    IData->>INews: new iNews(settings)
+    INews->>Sys: Connect(Servername, Username, Password)
+    INews->>Queue: SetCurrentQueue(queueName)
+    INews->>Queue: GetStories(IsStoryBodyIncluded=true)
+    Queue-->>INews: Stories[] (NSML)
+    INews-->>IData: List<string>
+    IData-->>UI: List<string>
+    UI->>Processing: Convert to DataTable
+    Processing-->>UI: DataTable
+```
+
+## Dịch vụ TCP nội bộ
+- `ServerAPI` nhận lệnh qua TCP (mặc định cổng do `ServerIP` xác định) như `GET_TREE`, `QUEUE|<FullName>`.
+- Với mỗi lệnh, server sử dụng lại instance `iNewsData` để đọc queue/story rồi trả về chuỗi (XML/NSML).
+- `ClientForm` dùng `ClientAPI.GetDataFromCmd` để gửi lệnh và hiển thị kết quả, phục vụ kiểm thử nhanh.
+
+## Parser & xử lý nội dung
+- `ProcessingXMl2Class` đọc `Fields` (ví dụ `title,page-number`) để map từng tag NSML vào cột `DataTable`.
+- Phần nội dung story gốc lưu vào `Content` để các nút xuất file dùng regex (`##CG`, `##DD`, `KeyTroiTin`, `KeyTroiCuoi`).
+- Xuất file sử dụng UTF-8 không BOM để bảo toàn dấu tiếng Việt.
+
+## Sơ đồ UML tổng quan
+```mermaid
+classDiagram
+    class API{
+        -ServerAPI server
+        -iNewsData iData
+        +ConnectServerToLoadDataAsync()
+        +LoadTreeStoriesAsync()
+        +GetDataContent()
+        +ProcessContentWithCG()
+    }
+    class ServerAPI{
+        +Start()
+        +Stop()
+        +ListenForClients()
+    }
+    class ClientAPI{
+        +GetDataFromCmd(cmd)
+    }
+    class iNewsData{
+        +GetFolderChildren(name)
+        +GetStoriesBoard(queue)
+        +ChangedQueues()
+        +SentError
+    }
+    class iNews{
+        +iNewsSystem
+        +iNewsQueue
+        +IsConnected()
+    }
+    class ProcessingXMl2Class{
+        +FieldMapping
+        +GetDataRows(nsmlList)
+    }
+    API --> ServerAPI
+    API --> iNewsData
+    ServerAPI --> iNewsData
+    ClientAPI --> ServerAPI
+    iNewsData --> iNews
+    iNews --> ProcessingXMl2Class
+```
+
+## Cấu trúc dữ liệu & cấu hình
+- **Không sử dụng database**; dữ liệu story nằm trong NSML trả về từ iNews.
+- `app.config` là nguồn cấu hình duy nhất cho thông tin kết nối, thư mục xuất file và khóa trích xuất.
+- `BarTypeConfiguration` đọc `BarScene` & `BarLocaltion` để hỗ trợ xuất bar value (dùng trong `APIV4`).
+
+## Đề xuất cải tiến
+- Xử lý triệt để nút `Get Stories` trống trong `ClientForm`.
+- Cân nhắc bỏ `ProcessContentWithPhude` và khóa `Phude` nếu không còn nhu cầu xuất file phụ đề.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,82 @@
-# API_iNews
+# INEWS Tools
 
-Ứng dụng WinForms kết nối tới máy chủ iNews để truy xuất dữ liệu và vận hành các dịch vụ API.
+## Tổng quan dự án
+INEWS Tools là ứng dụng WinForms dành cho biên tập viên khai thác rundown từ hệ thống iNews. Chương trình hỗ trợ:
 
-## Cấu hình
+- Duyệt cây rundown và xem chi tiết từng story theo node queue của iNews.
+- Trích xuất nhanh các trường biên tập (rút tít, địa danh, phần "trôi", nội dung thô) ra tệp văn bản cấu hình sẵn.
+- Cung cấp dịch vụ TCP nội bộ (ServerAPI) để client khác yêu cầu dữ liệu rundown/story theo thời gian thực.
 
-Các thông số kết nối và đường dẫn được cấu hình trong `API_iNews/app.config`. Ứng dụng đọc trực tiếp từ `appSettings` thông qua `ConfigurationManager.AppSettings`.
+Đối tượng sử dụng chính là nhóm biên tập chương trình truyền hình cần theo dõi rundown và chuẩn bị nội dung CG/Phụ đề.
 
-## Chạy ứng dụng
+## Cấu trúc thư mục
+| Đường dẫn | Mô tả |
+| --- | --- |
+| `News2025.sln` | Solution duy nhất của dự án WinForms. |
+| `API_iNews/Program.cs` | Điểm vào (`Main`) mở form `API`. |
+| `API_iNews/API*.cs` | Form chính: dựng cây queue, tải story, preview nội dung và nút xuất file. |
+| `API_iNews/App_Code/` | Lớp nghiệp vụ: SOAP client (`iNews`, `iNewsData`), TCP (`ServerAPI`, `ClientAPI`), parser (`ProcessingXMl2Class`), cấu hình bar. |
+| `API_iNews/Web References/` | Proxy SOAP sinh từ iNews (`INEWSSystem`, `INEWSQueue`, `INEWSStory`). |
+| `API_iNews/app.config` | Toàn bộ tham số kết nối server, thông tin đăng nhập, thư mục xuất file và khóa lọc nội dung. |
+| `API_iNews/ServerForm*`, `ClientForm*`, `APIV4*` | Form phụ điều khiển server, client kiểm thử và giao diện kế thừa với BarType. |
+| `API_iNews/Properties/` | Assembly info, resource và settings (bao gồm URL web service). |
 
-Mở solution `News2025.sln` trong Visual Studio và thiết lập `API_iNews` làm startup project. Khi chạy, ứng dụng mở trực tiếp form `API` để thao tác với dữ liệu từ iNews.
+## Cấu hình kết nối iNews
+Mọi thông số kết nối được nạp khi `API` khởi động thông qua `ConfigurationManager.AppSettings`. Những khóa quan trọng:
+
+| Khóa | Vai trò |
+| --- | --- |
+| `ServerIP` | IP mà `ServerAPI` lắng nghe TCP nội bộ. |
+| `iNewsServer` / `iNewsServerBackup` | Hostname/IP dịch vụ iNews Web Service (chính & dự phòng). |
+| `iNewsUser` / `iNewsPass` | Tài khoản đăng nhập web service iNews. |
+| `QueuesRoot` | Danh sách queue gốc (phân tách `;`) để dựng cây rundown. |
+| `QueuesChild` | Queue con mặc định đi kèm mỗi rundown. |
+| `WorkingFolder` | Thư mục gốc xuất file text. |
+| `Ruttit`, `Diadanh`, `TroiTin`, `TroiCuoi`, `Phude` | Đường dẫn tương đối dưới `WorkingFolder` cho từng loại file xuất. |
+| `KeyTroiTin`, `KeyTroiCuoi` | Mẫu khóa (dùng regex) trích phần trôi tin/trôi cuối từ nội dung story. |
+
+Các URL SOAP (`INEWSSystem`, `INEWSQueue`, `INEWSStory`) nằm trong mục `applicationSettings` và có thể chỉnh sửa trong Visual Studio (Project Settings \> Web Settings).
+
+## Workflow kết nối tới iNews
+1. `API.ConnectServerToLoadDataAsync` đọc `ServerIP`, khởi động `ServerAPI` và đăng ký sự kiện nhận tin.
+2. Hàm này đồng thời xây dựng `WebServiceSettings` từ `iNewsServer`, `iNewsServerBackup`, `iNewsUser`, `iNewsPass` rồi tạo `iNewsData`.
+3. Khi cần truy xuất, `iNewsData` khởi tạo `TTDH.iNews`, thiết lập `INEWSSystem` & `INEWSQueue` với `CookieContainer` chung và timeout 5 giây.
+4. `iNews` gọi `INEWSSystem.Connect` bằng `ConnectType` chứa `Servername`, `Username`, `Password`. Nếu lỗi kết nối và có `ServerBackup`, hàm thử lại.
+5. Sau khi kết nối thành công, các phương thức như `GetFolderChildren` và `GetStoriesBoard` sử dụng proxy trong `Web References` (SOAP) để lấy danh sách folder/story theo queue name.
+6. `GetStoriesBoard` gọi `SetCurrentQueue` trên `INEWSQueue`, sau đó `GetStories` với tham số `IsStoryBodyIncluded=true` để lấy NSML; chuỗi kết quả được `ProcessingXMl2Class` chuyển thành `DataTable` và hiển thị lên UI.
+
+Mọi lỗi kết nối hoặc SOAP exception sẽ được chuyển về UI thông qua sự kiện `iNewsData.SentError` để hiển thị trên `statusStrip`.
+
+## Build/Cài đặt/Chạy trên Windows
+1. Cài Visual Studio 2019/2022 với workload **.NET Desktop Development**.
+2. Mở `News2025.sln`, Visual Studio sẽ tự đặt `API_iNews` làm startup project.
+3. Chỉnh sửa `API_iNews/app.config` theo môi trường của bạn (IP server, tài khoản iNews, thư mục xuất file).
+4. Build solution ở cấu hình `Debug` hoặc `Release`. Khi build, VS sẽ tự phục hồi các Web Reference đã cấu hình.
+5. Nhấn **F5** để chạy. Form `API` sẽ tự khởi động, kết nối đến iNews, dựng cây rundown và mở dịch vụ TCP.
+
+## Hướng dẫn sử dụng chương trình
+### Duyệt rundown & xem story
+- Mở các node trong `treeView1` để lazy-load queue con. Mỗi node chạy `iNewsData.GetFolderChildren` tương ứng.
+- Chọn một rundown để tải stories. `dataGridView1` hiển thị danh sách story, `txtContent` preview chi tiết.
+
+### Xuất dữ liệu biên tập
+- **Xuất tất cả ra file**: trích phần CG (`##CG`) và địa danh (`##DD`) từ `Content`, ghi vào các file `Ruttit`, `Diadanh` (UTF-8).
+- **Xuất trôi tin - trôi cuối**: dùng khóa trong `KeyTroiTin`, `KeyTroiCuoi` để lọc nội dung, ghi vào `TroiTin` và `TroiCuoi`.
+- **Xuất nội dung gốc**: lưu toàn bộ story (kèm tên trong ngoặc vuông) qua `SaveFileDialog`.
+- **Xuất toàn bộ nội dung**: duyệt toàn cây rundown, gộp nội dung từng story và ghi ra tệp duy nhất.
+
+### Công cụ phụ trợ
+- `ServerForm`: điều khiển `ServerAPI`, mở form chính hoặc client test.
+- `ClientForm`: gửi lệnh TCP (`GET_TREE`, `QUEUE|…`) để xác thực dữ liệu trả về từ server.
+- `APIV4`: phiên bản giao diện cũ có hỗ trợ cấu hình BarType.
+
+## Dependencies & công nghệ
+- **.NET Framework 4.8**, C# WinForms.
+- `System.Configuration`, `System.Data`, `System.Net`, `System.IO`, `System.Text.RegularExpressions`.
+- Proxy SOAP sinh từ wsdl iNews (INEWSSystem, INEWSQueue, INEWSStory).
+- Không sử dụng cơ sở dữ liệu cục bộ; dữ liệu dạng NSML được chuyển sang `DataTable` trong bộ nhớ.
+
+## Lưu ý tối ưu
+- Hàm `ProcessContentWithPhude` chưa được sử dụng; có thể cân nhắc loại bỏ cùng khóa `Phude` trong cấu hình.
+- Nút "Get Stories" trên `ClientForm` không có xử lý, nên bổ sung logic hoặc ẩn để tránh nhầm lẫn.
+


### PR DESCRIPTION
## Summary
- replace the root README with a detailed guide on configuring and using the WinForms app, including the iNews connection workflow
- add a ProjectOverview document with architecture diagrams and SOAP connection flow details
- document contribution guidelines and module responsibilities with emphasis on configuration keys and unused components

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df481b92b48321816eb0c2a42fbd02