### PR TITLE
Add .NET Framework BridgeHost TCP server to expose iNews SOAP logic for .NET 10 clients

### DIFF
--- a/INews.BridgeHost/App.config
+++ b/INews.BridgeHost/App.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="BridgeHostIP" value="127.0.0.1" />
+    <add key="BridgeHostPort" value="3000" />
+    <add key="QueuesRoot" value="VTV4.04_VO_BAN_TIN" />
+    <add key="Fields" value="title,page-number" />
+    <add key="iNewsServer" value="192.88.8.21" />
+    <add key="iNewsServerBackup" value="192.88.8.22" />
+    <add key="iNewsUser" value="checkfile" />
+    <add key="iNewsPass" value="12345678" />
+    <add key="iNewsTimeout" value="5000" />
+  </appSettings>
+</configuration>

--- a/INews.BridgeHost/BridgeServer.cs
+++ b/INews.BridgeHost/BridgeServer.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Xml;
+
+namespace INews.BridgeHost
+{
+    public class BridgeServer
+    {
+        private readonly TcpListener _listener;
+        private readonly Thread _listenThread;
+        private readonly API_iNews.INewsDataProvider _dataProvider;
+        private readonly string _fieldMapping;
+        private readonly string _queuesRoot;
+        private readonly object _syncRoot = new object();
+        private bool _isStopping;
+
+        public BridgeServer(IPAddress ipAddress, int port, API_iNews.INewsDataProvider dataProvider)
+        {
+            _listener = new TcpListener(ipAddress, port);
+            _dataProvider = dataProvider;
+            _fieldMapping = ConfigurationManager.AppSettings["Fields"] ?? "title,page-number";
+            _queuesRoot = ConfigurationManager.AppSettings["QueuesRoot"] ?? string.Empty;
+            _listenThread = new Thread(ListenLoop)
+            {
+                IsBackground = true,
+                Name = "INEWS Bridge Host"
+            };
+        }
+
+        public void Start()
+        {
+            _listener.Start();
+            _listenThread.Start();
+        }
+
+        public void Stop()
+        {
+            lock (_syncRoot)
+            {
+                if (_isStopping) return;
+                _isStopping = true;
+            }
+
+            _listener.Stop();
+            if (Thread.CurrentThread != _listenThread)
+            {
+                _listenThread.Join(TimeSpan.FromSeconds(2));
+            }
+        }
+
+        private void ListenLoop()
+        {
+            try
+            {
+                while (true)
+                {
+                    TcpClient client = _listener.AcceptTcpClient();
+                    using (client)
+                    using (NetworkStream stream = client.GetStream())
+                    {
+                        string cmd = ReadCommand(stream);
+                        if (string.IsNullOrWhiteSpace(cmd)) continue;
+
+                        string response = HandleCommand(cmd.Trim());
+                        if (!string.IsNullOrEmpty(response))
+                        {
+                            byte[] payload = Encoding.UTF8.GetBytes(response);
+                            client.ReceiveBufferSize = payload.Length;
+                            stream.Write(payload, 0, payload.Length);
+                        }
+                    }
+                }
+            }
+            catch (SocketException)
+            {
+                if (!_isStopping)
+                {
+                    throw;
+                }
+            }
+        }
+
+        private static string ReadCommand(NetworkStream stream)
+        {
+            byte[] buffer = new byte[1024];
+            int bytesRead = stream.Read(buffer, 0, buffer.Length);
+            if (bytesRead <= 0) return string.Empty;
+            return Encoding.UTF8.GetString(buffer, 0, bytesRead).Replace("\0", string.Empty);
+        }
+
+        private string HandleCommand(string cmd)
+        {
+            if (string.Equals(cmd, "PING", StringComparison.OrdinalIgnoreCase))
+            {
+                return "OK";
+            }
+
+            if (string.Equals(cmd, "GET_TREE", StringComparison.OrdinalIgnoreCase))
+            {
+                return SerializeArrayToString(BuildQueueTree());
+            }
+
+            if (string.Equals(cmd, "GET_SCROLL_TEXT", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            return SerializeStories(cmd);
+        }
+
+        private string SerializeStories(string cmd)
+        {
+            string[] parts = cmd.Split(new[] { "|", "#" }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2)
+            {
+                return "ERROR:INVALID_COMMAND";
+            }
+
+            try
+            {
+                string queueName = parts[1];
+                DataTable table = _dataProvider.GetStoriesAsDataTable(queueName, _fieldMapping);
+                return SerializeTableToString(table);
+            }
+            catch (Exception ex)
+            {
+                return "ERROR:" + ex.Message;
+            }
+        }
+
+        private List<string> BuildQueueTree()
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(_queuesRoot)) return result;
+
+            string[] roots = _queuesRoot.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string root in roots)
+            {
+                string trimmed = root.Trim();
+                if (string.IsNullOrEmpty(trimmed)) continue;
+
+                result.Add("{" + trimmed + ":");
+                List<string> children = _dataProvider.GetFolderChildren(trimmed);
+                foreach (string child in children)
+                {
+                    result.Add(child);
+                }
+                result.Add("}");
+            }
+
+            return result;
+        }
+
+        private static string SerializeArrayToString(List<string> items)
+        {
+            if (items == null || items.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Join("|", items) + "|";
+        }
+
+        private static string SerializeTableToString(DataTable table)
+        {
+            if (table == null)
+            {
+                table = new DataTable();
+            }
+
+            using (var sw = new StringWriter())
+            using (var xmlWriter = new XmlTextWriter(sw))
+            {
+                table.TableName = "Stories";
+                xmlWriter.Formatting = Formatting.Indented;
+                xmlWriter.WriteStartDocument();
+                xmlWriter.WriteStartElement("data");
+                ((System.Xml.Serialization.IXmlSerializable)table).WriteXml(xmlWriter);
+                xmlWriter.WriteEndElement();
+                xmlWriter.WriteEndDocument();
+                xmlWriter.Flush();
+                sw.Flush();
+                return sw.ToString();
+            }
+        }
+    }
+}

--- a/INews.BridgeHost/INews.BridgeHost.csproj
+++ b/INews.BridgeHost/INews.BridgeHost.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>INews.BridgeHost</RootNamespace>
+    <AssemblyName>INews.BridgeHost</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BridgeServer.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\INews.Library\INews.Library.csproj">
+      <Project>{8CDD629B-11FD-4675-8409-B342CD20E431}</Project>
+      <Name>INews.Library</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/INews.BridgeHost/Program.cs
+++ b/INews.BridgeHost/Program.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Configuration;
+using System.Net;
+
+namespace INews.BridgeHost
+{
+    internal class Program
+    {
+        private static int Main(string[] args)
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            Console.WriteLine("INEWS Bridge Host (NET Framework 4.8)");
+
+            var config = LoadConfig();
+            var connection = new API_iNews.INewsConnection(config);
+            var provider = new API_iNews.INewsDataProvider(connection);
+
+            string ipSetting = ConfigurationManager.AppSettings["BridgeHostIP"] ?? "127.0.0.1";
+            string portSetting = ConfigurationManager.AppSettings["BridgeHostPort"] ?? "3000";
+
+            if (!IPAddress.TryParse(ipSetting, out IPAddress ipAddress))
+            {
+                Console.WriteLine($"Invalid BridgeHostIP '{ipSetting}'.");
+                return 1;
+            }
+
+            if (!int.TryParse(portSetting, out int port))
+            {
+                Console.WriteLine($"Invalid BridgeHostPort '{portSetting}'.");
+                return 1;
+            }
+
+            var server = new BridgeServer(ipAddress, port, provider);
+            server.Start();
+
+            Console.WriteLine($"Listening on {ipAddress}:{port}");
+            Console.WriteLine("Commands: GET_TREE | QUEUE|<queue-fullname> | PING");
+            Console.WriteLine("Press ENTER to stop.");
+
+            Console.ReadLine();
+            server.Stop();
+            connection.Dispose();
+
+            return 0;
+        }
+
+        private static API_iNews.INewsConfig LoadConfig()
+        {
+            return new API_iNews.INewsConfig
+            {
+                Server = ConfigurationManager.AppSettings["iNewsServer"] ?? "192.88.8.21",
+                BackupServer = ConfigurationManager.AppSettings["iNewsServerBackup"] ?? "",
+                Username = ConfigurationManager.AppSettings["iNewsUser"] ?? "",
+                Password = ConfigurationManager.AppSettings["iNewsPass"] ?? "",
+                Timeout = ParseIntSetting("iNewsTimeout", 5000),
+                FieldMapping = ConfigurationManager.AppSettings["Fields"] ?? "title,page-number"
+            };
+        }
+
+        private static int ParseIntSetting(string key, int defaultValue)
+        {
+            string value = ConfigurationManager.AppSettings[key];
+            return int.TryParse(value, out int parsed) ? parsed : defaultValue;
+        }
+    }
+}

--- a/INews.Library/INews.Library.sln
+++ b/INews.Library/INews.Library.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 18.1.11304.174 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "INews.Library", "INews.Library.csproj", "{8CDD629B-11FD-4675-8409-B342CD20E431}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "INews.BridgeHost", "..\\INews.BridgeHost\\INews.BridgeHost.csproj", "{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +23,14 @@ Global
 		{8CDD629B-11FD-4675-8409-B342CD20E431}.Release|x64.Build.0 = Release|x64
 		{8CDD629B-11FD-4675-8409-B342CD20E431}.Release|x86.ActiveCfg = Release|x86
 		{8CDD629B-11FD-4675-8409-B342CD20E431}.Release|x86.Build.0 = Release|x86
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Debug|x64.Build.0 = Debug|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Debug|x86.Build.0 = Debug|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Release|x64.ActiveCfg = Release|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Release|x64.Build.0 = Release|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Release|x86.ActiveCfg = Release|Any CPU
+		{0CB7BAA8-09B5-4A35-A8B2-58C4B6E33E19}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/INews.Library/INewsDataProvider.cs
+++ b/INews.Library/INewsDataProvider.cs
@@ -54,5 +54,37 @@ namespace API_iNews
             var xmlList = GetStoriesXml(queuePath);
             return StoryXmlParser.ToDataTable(xmlList, fieldMapping);
         }
+
+        public List<string> GetFolderChildren(string folderPath)
+        {
+            var result = new List<string>();
+            if (!_connection.Connect()) return result;
+
+            try
+            {
+                var request = new API_iNews.INEWSSystem.GetFolderChildrenType
+                {
+                    FolderFullName = folderPath
+                };
+
+                var response = _connection.SystemService.GetFolderChildren(request);
+                if (response?.Children != null)
+                {
+                    foreach (var child in response.Children)
+                    {
+                        if (!string.IsNullOrEmpty(child?.Name))
+                        {
+                            result.Add(child.Name);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"GetFolderChildren Error: {ex.Message}");
+            }
+
+            return result;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,20 @@ Mọi lỗi kết nối hoặc SOAP exception sẽ được chuyển về UI th�
 - Proxy SOAP sinh từ wsdl iNews (INEWSSystem, INEWSQueue, INEWSStory).
 - Không sử dụng cơ sở dữ liệu cục bộ; dữ liệu dạng NSML được chuyển sang `DataTable` trong bộ nhớ.
 
+## Bridge cho WPF .NET 10 (Option 3)
+Nếu cần giữ SOAP client .NET Framework 4.8 nhưng muốn WPF .NET 10 gọi qua API, dùng project `INews.BridgeHost` để chạy TCP server (giao thức giống `ServerAPI`/`ClientAPI`).
+
+### Cách chạy BridgeHost
+1. Mở solution `INews.Library/INews.Library.sln`.
+2. Set startup project: `INews.BridgeHost`.
+3. Cập nhật `INews.BridgeHost/App.config` cho `iNewsServer`, `iNewsUser`, `QueuesRoot`, `Fields`, `BridgeHostIP`, `BridgeHostPort`.
+4. Run (F5). Console sẽ lắng nghe TCP và trả dữ liệu DataTable dạng XML.
+
+### Lệnh TCP hỗ trợ
+- `PING` → trả `OK`
+- `GET_TREE` → trả cây queue theo `QueuesRoot`
+- `QUEUE|<QueueFullName>` → trả XML `DataTable` của stories
+
 ## Lưu ý tối ưu
 - Hàm `ProcessContentWithPhude` chưa được sử dụng; có thể cân nhắc loại bỏ cùng khóa `Phude` trong cấu hình.
 - Nút "Get Stories" trên `ClientForm` không có xử lý, nên bổ sung logic hoặc ẩn để tránh nhầm lẫn.
-


### PR DESCRIPTION
### Motivation
- Keep the existing iNews SOAP client and logic on .NET Framework 4.8 while allowing a WPF .NET 10 app to call the same functionality via a lightweight TCP API bridge. 
- Provide an immediate, low-effort interoperability path (Option 3: Bridge) so the current business logic runs unchanged when invoked from .NET 10.

### Description
- Add a new .NET Framework 4.8 console project `INews.BridgeHost` that hosts a TCP server implemented in `BridgeServer.cs` and a simple runner in `Program.cs`, with settings in `App.config` and project file `INews.BridgeHost.csproj`.
- Implement commands `PING`, `GET_TREE`, `GET_SCROLL_TEXT` and `QUEUE|<QueueFullName>` over TCP and serialize returned `DataTable` to XML for client consumption using the same DataTable/XML format the existing `ServerAPI` used.
- Extend `INews.Library` by adding `GetFolderChildren` to `INewsDataProvider` to support `GET_TREE` behavior via the existing SOAP client types (`INEWSSystem`), and add the `INews.BridgeHost` project to the solution file (`INews.Library.sln`).
- Update `README.md` with run instructions and the supported TCP command list; configuration keys documented include `BridgeHostIP`, `BridgeHostPort`, `QueuesRoot`, `Fields`, and iNews connection settings.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971aa2b783c832cb9a53fafae3998b8)